### PR TITLE
Enumerable

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -98,7 +98,7 @@ Style/ClassCheck:
 Style/CollectionMethods:
   Description: Preferred collection methods.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#map-find-select-reduce-size
-  Enabled: true
+  Enabled: false
   PreferredMethods:
     collect: map
     collect!: map!


### PR DESCRIPTION
Remove collection method defaults as Enumerable methods are meant for readability not standardization.
